### PR TITLE
Implement fetch for arbitrary TLV values

### DIFF
--- a/doc/configuration.txt
+++ b/doc/configuration.txt
@@ -20131,6 +20131,10 @@ fc_pp_unique_id : string
   Returns the unique ID TLV sent by the client in the PROXY protocol header,
   if any.
 
+fc_pp_tlv(<id>) : string
+  Returns the TLV value for the given ID sent by the client in the PROXY
+  protocol header, if any.
+
 fc_rcvd_proxy : boolean
   Returns true if the client initiated the connection with a PROXY protocol
   header.

--- a/doc/configuration.txt
+++ b/doc/configuration.txt
@@ -20131,9 +20131,10 @@ fc_pp_unique_id : string
   Returns the unique ID TLV sent by the client in the PROXY protocol header,
   if any.
 
-fc_pp_tlv(<id>) : string
-  Returns the TLV value for the given ID sent by the client in the PROXY
-  protocol header, if any.
+fc_pp_tlv(<tlv>) : string
+  Returns the TLV value for the given TLV ID or type constant sent by the
+  client in the PROXY protocol header, if any. TLV constants correspond
+  to their type suffix as specified in the PPv2 spec, e.g., AUTHORITY.
 
 fc_rcvd_proxy : boolean
   Returns true if the client initiated the connection with a PROXY protocol

--- a/include/haproxy/connection-t.h
+++ b/include/haproxy/connection-t.h
@@ -501,6 +501,19 @@ struct conn_hash_params {
 	struct sockaddr_storage *dst_addr;
 };
 
+/*
+ * This structure describes an TLV entry consisting of its type
+ * and corresponding payload. This can be used to construct a list
+ * from which arbitrary TLV payloads can be fetched.
+ * It might be possible to embed the 'tlv struct' here in the future.
+ */
+struct conn_tlv_list {
+	struct list list;
+	unsigned char type;
+	unsigned short len; // 65535 should be more than enough!
+	char value[0];
+} __attribute__((packed));
+
 /* This structure describes a connection with its methods and data.
  * A connection may be performed to proxy or server via a local or remote
  * socket, and can also be made to an internal applet. It can support
@@ -536,8 +549,7 @@ struct connection {
 	void (*destroy_cb)(struct connection *conn);  /* callback to notify of imminent death of the connection */
 	struct sockaddr_storage *src; /* source address (pool), when known, otherwise NULL */
 	struct sockaddr_storage *dst; /* destination address (pool), when known, otherwise NULL */
-	struct ist proxy_authority;   /* Value of the authority TLV received via PROXYv2 */
-	struct ist proxy_unique_id;   /* Value of the unique ID TLV received via PROXYv2 */
+	struct list tlv_list;         /* list of TLVs received via PROXYv2 */
 
 	/* used to identify a backend connection for http-reuse,
 	 * thus only present if conn.target is of type OBJ_TYPE_SERVER
@@ -619,7 +631,10 @@ struct mux_proto_list {
 
 #define TLV_HEADER_SIZE 3
 
-#define HA_PP2_AUTHORITY_MAX 255 /* Maximum length of an authority TLV */
+#define HA_PP2_AUTHORITY_MAX 255  /* Maximum length of an authority TLV */
+#define HA_PP2_TLV_VALUE_128 128  /* E.g., accomodate unique IDs (128 B) */
+#define HA_PP2_TLV_VALUE_256 256  /* E.g., accomodate authority TLVs (currently, <= 255 B) */
+#define HA_PP2_MAX_ALLOC     1024 /* Maximum TLV value for PPv2 to prevent DoS */
 
 struct proxy_hdr_v2 {
 	uint8_t sig[12];   /* hex 0D 0A 0D 0A 00 0D 0A 51 55 49 54 0A */

--- a/include/haproxy/connection-t.h
+++ b/include/haproxy/connection-t.h
@@ -615,10 +615,11 @@ struct mux_proto_list {
 #define PP2_CLIENT_CERT_CONN     0x02
 #define PP2_CLIENT_CERT_SESS     0x04
 
-/* Max length of the authority TLV */
-#define PP2_AUTHORITY_MAX 255
+#define PP2_CRC32C_LEN 4 /* Length of a CRC32C TLV value */
 
-#define TLV_HEADER_SIZE      3
+#define TLV_HEADER_SIZE 3
+
+#define HA_PP2_AUTHORITY_MAX 255 /* Maximum length of an authority TLV */
 
 struct proxy_hdr_v2 {
 	uint8_t sig[12];   /* hex 0D 0A 0D 0A 00 0D 0A 51 55 49 54 0A */

--- a/include/haproxy/connection.h
+++ b/include/haproxy/connection.h
@@ -40,7 +40,8 @@
 extern struct pool_head *pool_head_connection;
 extern struct pool_head *pool_head_conn_hash_node;
 extern struct pool_head *pool_head_sockaddr;
-extern struct pool_head *pool_head_authority;
+extern struct pool_head *pool_head_pp_tlv_128;
+extern struct pool_head *pool_head_pp_tlv_256;
 extern struct pool_head *pool_head_uniqueid;
 extern struct xprt_ops *registered_xprt[XPRT_ENTRIES];
 extern struct mux_proto_list mux_proto_list;
@@ -52,6 +53,7 @@ extern struct mux_stopping_data mux_stopping_data[MAX_THREADS];
 int conn_recv_proxy(struct connection *conn, int flag);
 int conn_send_proxy(struct connection *conn, unsigned int flag);
 int make_proxy_line(char *buf, int buf_len, struct server *srv, struct connection *remote, struct stream *strm);
+struct conn_tlv_list *conn_get_tlv(struct connection *conn, int type);
 
 int conn_append_debug_info(struct buffer *buf, const struct connection *conn, const char *pfx);
 

--- a/include/haproxy/connection.h
+++ b/include/haproxy/connection.h
@@ -696,6 +696,20 @@ static inline int conn_is_ssl(struct connection *conn)
 	return !!conn_get_ssl_sock_ctx(conn);
 }
 
+/*
+ * Prepare TLV argument for redirecting fetches.
+ * Note that it is not possible to use an argument check function
+ * as that would require us to allow arguments for functions
+ * that do not need it. Alternatively, the sample logic could be
+ * adjusted to perform checks for no arguments and allocate
+ * in the check function. However, this does not seem worth the trouble.
+ */
+static inline void set_tlv_arg(int tlv_type, struct arg *tlv_arg)
+{
+	tlv_arg->type = ARGT_SINT;
+	tlv_arg->data.sint = tlv_type;
+}
+
 #endif /* _HAPROXY_CONNECTION_H */
 
 /*

--- a/src/connection.c
+++ b/src/connection.c
@@ -2277,34 +2277,10 @@ int smp_fetch_fc_pp_authority(const struct arg *args, struct sample *smp, const 
 /* fetch the unique ID TLV from a PROXY protocol header */
 int smp_fetch_fc_pp_unique_id(const struct arg *args, struct sample *smp, const char *kw, void *private)
 {
-	struct connection *conn = NULL;
-	struct conn_tlv_list *conn_tlv = NULL;
+	struct arg tlv_arg;
 
-	conn = objt_conn(smp->sess->origin);
-	if (!conn)
-		return 0;
-
-	if (conn->flags & CO_FL_WAIT_XPRT) {
-		smp->flags |= SMP_F_MAY_CHANGE;
-		return 0;
-	}
-
-	conn_tlv = smp->ctx.p ? smp->ctx.p : LIST_ELEM(conn->tlv_list.n, struct conn_tlv_list *, list);
-	list_for_each_entry_from(conn_tlv, &conn->tlv_list, list) {
-		if (conn_tlv->type == PP2_TYPE_UNIQUE_ID) {
-			smp->flags |= SMP_F_NOT_LAST;
-			smp->data.type = SMP_T_STR;
-			smp->data.u.str.area = conn_tlv->value;
-			smp->data.u.str.data = conn_tlv->len;
-			smp->ctx.p = conn_tlv;
-
-			return 1;
-		}
-	}
-
-	smp->flags &= ~SMP_F_NOT_LAST;
-
-	return 0;
+	set_tlv_arg(PP2_TYPE_UNIQUE_ID, &tlv_arg);
+	return smp_fetch_fc_pp_tlv(&tlv_arg, smp, kw, private);
 }
 
 /* fetch the error code of a connection */

--- a/src/connection.c
+++ b/src/connection.c
@@ -37,7 +37,8 @@
 DECLARE_POOL(pool_head_connection,     "connection",     sizeof(struct connection));
 DECLARE_POOL(pool_head_conn_hash_node, "conn_hash_node", sizeof(struct conn_hash_node));
 DECLARE_POOL(pool_head_sockaddr,       "sockaddr",       sizeof(struct sockaddr_storage));
-DECLARE_POOL(pool_head_authority,      "authority",      HA_PP2_AUTHORITY_MAX);
+DECLARE_POOL(pool_head_pp_tlv_128,     "pp_tlv_128",     sizeof(struct conn_tlv_list) + HA_PP2_TLV_VALUE_128);
+DECLARE_POOL(pool_head_pp_tlv_256,     "pp_tlv_256",     sizeof(struct conn_tlv_list) + HA_PP2_TLV_VALUE_256);
 
 struct idle_conns idle_conns[MAX_THREADS] = { };
 struct xprt_ops *registered_xprt[XPRT_ENTRIES] = { NULL, };
@@ -51,6 +52,22 @@ struct mux_stopping_data mux_stopping_data[MAX_THREADS];
 
 /* disables sending of proxy-protocol-v2's LOCAL command */
 static int pp2_never_send_local;
+
+/* find the value of a received TLV for a given type */
+struct conn_tlv_list *conn_get_tlv(struct connection *conn, int type)
+{
+	struct conn_tlv_list *tlv = NULL;
+
+	if (!conn)
+		return NULL;
+
+	list_for_each_entry(tlv, &conn->tlv_list, list) {
+		if (tlv->type == type)
+			return tlv;
+	}
+
+	return NULL;
+}
 
 void conn_delete_from_tree(struct eb64_node *node)
 {
@@ -428,11 +445,10 @@ void conn_init(struct connection *conn, void *target)
 		LIST_INIT(&conn->session_list);
 	else
 		LIST_INIT(&conn->stopping_list);
+	LIST_INIT(&conn->tlv_list);
 	conn->subs = NULL;
 	conn->src = NULL;
 	conn->dst = NULL;
-	conn->proxy_authority = IST_NULL;
-	conn->proxy_unique_id = IST_NULL;
 	conn->hash_node = NULL;
 	conn->xprt = NULL;
 }
@@ -471,6 +487,8 @@ struct connection *conn_new(void *target)
 /* Releases a connection previously allocated by conn_new() */
 void conn_free(struct connection *conn)
 {
+	struct conn_tlv_list *tlv, *tlv_back = NULL;
+
 	/* If the connection is owned by the session, remove it from its list
 	 */
 	if (conn_is_back(conn) && LIST_INLIST(&conn->session_list)) {
@@ -492,11 +510,16 @@ void conn_free(struct connection *conn)
 	sockaddr_free(&conn->src);
 	sockaddr_free(&conn->dst);
 
-	pool_free(pool_head_authority, istptr(conn->proxy_authority));
-	conn->proxy_authority = IST_NULL;
-
-	pool_free(pool_head_uniqueid, istptr(conn->proxy_unique_id));
-	conn->proxy_unique_id = IST_NULL;
+	/* Free all previously allocated TLVs */
+	list_for_each_entry_safe(tlv, tlv_back, &conn->tlv_list, list) {
+		LIST_DELETE(&tlv->list);
+		if (tlv->len > HA_PP2_TLV_VALUE_256)
+			free(tlv);
+		else if (tlv->len < HA_PP2_TLV_VALUE_128)
+			pool_free(pool_head_pp_tlv_128, tlv);
+		else
+			pool_free(pool_head_pp_tlv_256, tlv);
+	}
 
 	/* Make sure the connection is not left in the idle connection tree */
 	if (conn->hash_node != NULL)
@@ -1020,8 +1043,10 @@ int conn_recv_proxy(struct connection *conn, int flag)
 
 		/* TLV parsing */
 		while (tlv_offset < total_v2_len) {
-			struct tlv *tlv_packet;
 			struct ist tlv;
+			struct tlv *tlv_packet = NULL;
+			struct conn_tlv_list *new_tlv = NULL;
+			size_t data_len = 0;
 
 			/* Verify that we have at least TLV_HEADER_SIZE bytes left */
 			if (tlv_offset + TLV_HEADER_SIZE > total_v2_len)
@@ -1035,6 +1060,7 @@ int conn_recv_proxy(struct connection *conn, int flag)
 			if (tlv_offset > total_v2_len)
 				goto bad_header;
 
+			/* Prepare known TLV types */
 			switch (tlv_packet->type) {
 			case PP2_TYPE_CRC32C: {
 				uint32_t n_crc32c;
@@ -1061,35 +1087,48 @@ int conn_recv_proxy(struct connection *conn, int flag)
 			}
 #endif
 			case PP2_TYPE_AUTHORITY: {
+				/* For now, keep the length restriction by HAProxy */
 				if (istlen(tlv) > HA_PP2_AUTHORITY_MAX)
 					goto bad_header;
-				conn->proxy_authority = ist2(pool_alloc(pool_head_authority), 0);
-				if (!isttest(conn->proxy_authority))
-					goto fail;
-				if (istcpy(&conn->proxy_authority, tlv, HA_PP2_AUTHORITY_MAX) < 0) {
-					/* This is impossible, because we verified that the TLV value fits. */
-					my_unreachable();
-					goto fail;
-				}
+
 				break;
 			}
 			case PP2_TYPE_UNIQUE_ID: {
 				if (istlen(tlv) > UNIQUEID_LEN)
 					goto bad_header;
-				conn->proxy_unique_id = ist2(pool_alloc(pool_head_uniqueid), 0);
-				if (!isttest(conn->proxy_unique_id))
-					goto fail;
-				if (istcpy(&conn->proxy_unique_id, tlv, UNIQUEID_LEN) < 0) {
-					/* This is impossible, because we verified that the TLV value fits. */
-					my_unreachable();
-					goto fail;
-				}
 				break;
 			}
 			default:
 				break;
 			}
+
+			/* If we did not find a known TLV type that we can optimize for, we generically allocate it */
+			data_len = get_tlv_length(tlv_packet);
+
+			/* Prevent attackers from allocating too much memory */
+			if (unlikely(data_len > HA_PP2_MAX_ALLOC))
+				goto fail;
+
+			/* Alloc memory based on data_len */
+			if (data_len > HA_PP2_TLV_VALUE_256)
+				new_tlv = malloc(get_tlv_length(tlv_packet) + sizeof(struct conn_tlv_list));
+			else if (data_len <= HA_PP2_TLV_VALUE_128)
+				new_tlv = pool_alloc(pool_head_pp_tlv_128);
+			else
+				new_tlv = pool_alloc(pool_head_pp_tlv_256);
+
+			if (unlikely(!new_tlv))
+				goto fail;
+
+			new_tlv->type = tlv_packet->type;
+
+			/* Save TLV to make it accessible via sample fetch */
+			memcpy(new_tlv->value, tlv.ptr, data_len);
+			new_tlv->len = data_len;
+
+			LIST_APPEND(&conn->tlv_list, &new_tlv->list);
 		}
+
 
 		/* Verify that the PROXYv2 header ends at a TLV boundary.
 		 * This is can not be true, because the TLV parsing already
@@ -1909,10 +1948,12 @@ static int make_proxy_line_v2(char *buf, int buf_len, struct server *srv, struct
 	}
 
 	if (srv->pp_opts & SRV_PP_V2_AUTHORITY) {
+		struct conn_tlv_list *tlv = conn_get_tlv(remote, PP2_TYPE_AUTHORITY);
+
 		value = NULL;
-		if (remote && isttest(remote->proxy_authority)) {
-			value = istptr(remote->proxy_authority);
-			value_len = istlen(remote->proxy_authority);
+		if (tlv) {
+			value_len = tlv->len;
+			value = tlv->value;
 		}
 #ifdef USE_OPENSSL
 		else {
@@ -2160,7 +2201,8 @@ int smp_fetch_fc_rcvd_proxy(const struct arg *args, struct sample *smp, const ch
 /* fetch the authority TLV from a PROXY protocol header */
 int smp_fetch_fc_pp_authority(const struct arg *args, struct sample *smp, const char *kw, void *private)
 {
-	struct connection *conn;
+	struct connection *conn = NULL;
+	struct conn_tlv_list *conn_tlv;
 
 	conn = objt_conn(smp->sess->origin);
 	if (!conn)
@@ -2171,21 +2213,29 @@ int smp_fetch_fc_pp_authority(const struct arg *args, struct sample *smp, const 
 		return 0;
 	}
 
-	if (!isttest(conn->proxy_authority))
-		return 0;
+	conn_tlv = smp->ctx.p ? smp->ctx.p : LIST_ELEM(conn->tlv_list.n, struct conn_tlv_list *, list);
+	list_for_each_entry_from(conn_tlv, &conn->tlv_list, list) {
+		if (conn_tlv->type == PP2_TYPE_AUTHORITY) {
+			smp->flags |= SMP_F_NOT_LAST;
+			smp->data.type = SMP_T_STR;
+			smp->data.u.str.area = conn_tlv->value;
+			smp->data.u.str.data = conn_tlv->len;
+			smp->ctx.p = conn_tlv;
 
-	smp->flags = 0;
-	smp->data.type = SMP_T_STR;
-	smp->data.u.str.area = istptr(conn->proxy_authority);
-	smp->data.u.str.data = istlen(conn->proxy_authority);
+			return 1;
+		}
+	}
 
-	return 1;
+	smp->flags &= ~SMP_F_NOT_LAST;
+
+	return 0;
 }
 
 /* fetch the unique ID TLV from a PROXY protocol header */
 int smp_fetch_fc_pp_unique_id(const struct arg *args, struct sample *smp, const char *kw, void *private)
 {
-	struct connection *conn;
+	struct connection *conn = NULL;
+	struct conn_tlv_list *conn_tlv;
 
 	conn = objt_conn(smp->sess->origin);
 	if (!conn)
@@ -2196,15 +2246,22 @@ int smp_fetch_fc_pp_unique_id(const struct arg *args, struct sample *smp, const 
 		return 0;
 	}
 
-	if (!isttest(conn->proxy_unique_id))
-		return 0;
+	conn_tlv = smp->ctx.p ? smp->ctx.p : LIST_ELEM(conn->tlv_list.n, struct conn_tlv_list *, list);
+	list_for_each_entry_from(conn_tlv, &conn->tlv_list, list) {
+		if (conn_tlv->type == PP2_TYPE_UNIQUE_ID) {
+			smp->flags |= SMP_F_NOT_LAST;
+			smp->data.type = SMP_T_STR;
+			smp->data.u.str.area = conn_tlv->value;
+			smp->data.u.str.data = conn_tlv->len;
+			smp->ctx.p = conn_tlv;
 
-	smp->flags = 0;
-	smp->data.type = SMP_T_STR;
-	smp->data.u.str.area = istptr(conn->proxy_unique_id);
-	smp->data.u.str.data = istlen(conn->proxy_unique_id);
+			return 1;
+		}
+	}
 
-	return 1;
+	smp->flags &= ~SMP_F_NOT_LAST;
+
+	return 0;
 }
 
 /* fetch the error code of a connection */

--- a/src/connection.c
+++ b/src/connection.c
@@ -2268,34 +2268,10 @@ int smp_fetch_fc_pp_tlv(const struct arg *args, struct sample *smp, const char *
 /* fetch the authority TLV from a PROXY protocol header */
 int smp_fetch_fc_pp_authority(const struct arg *args, struct sample *smp, const char *kw, void *private)
 {
-	struct connection *conn = NULL;
-	struct conn_tlv_list *conn_tlv = NULL;
+	struct arg tlv_arg;
 
-	conn = objt_conn(smp->sess->origin);
-	if (!conn)
-		return 0;
-
-	if (conn->flags & CO_FL_WAIT_XPRT) {
-		smp->flags |= SMP_F_MAY_CHANGE;
-		return 0;
-	}
-
-	conn_tlv = smp->ctx.p ? smp->ctx.p : LIST_ELEM(conn->tlv_list.n, struct conn_tlv_list *, list);
-	list_for_each_entry_from(conn_tlv, &conn->tlv_list, list) {
-		if (conn_tlv->type == PP2_TYPE_AUTHORITY) {
-			smp->flags |= SMP_F_NOT_LAST;
-			smp->data.type = SMP_T_STR;
-			smp->data.u.str.area = conn_tlv->value;
-			smp->data.u.str.data = conn_tlv->len;
-			smp->ctx.p = conn_tlv;
-
-			return 1;
-		}
-	}
-
-	smp->flags &= ~SMP_F_NOT_LAST;
-
-	return 0;
+	set_tlv_arg(PP2_TYPE_AUTHORITY, &tlv_arg);
+	return smp_fetch_fc_pp_tlv(&tlv_arg, smp, kw, private);
 }
 
 /* fetch the unique ID TLV from a PROXY protocol header */

--- a/src/connection.c
+++ b/src/connection.c
@@ -2201,22 +2201,50 @@ int smp_fetch_fc_rcvd_proxy(const struct arg *args, struct sample *smp, const ch
 
 /*
  * This function checks the TLV type converter configuration.
- * It expects the corresponding TLV type as a string representing the number.
- * args[0] will be turned into the numerical value of the TLV type string.
+ * It expects the corresponding TLV type as a string representing the number
+ * or a constant. args[0] will be turned into the numerical value of the
+ * TLV type string.
  */
 static int smp_check_tlv_type(struct arg *args, char **err)
 {
 	int type;
 	char *endp;
+	struct ist input = ist2(args[0].data.str.area, args[0].data.str.data);
 
-	type = strtoul(args[0].data.str.area, &endp, 0);
-	if (endp && *endp != '\0') {
-		memprintf(err, "Could not convert type '%s'", args[0].data.str.area);
-		return 0;
+	if (isteqi(input, ist("ALPN")) != 0)
+		type = PP2_TYPE_ALPN;
+	else if (isteqi(input, ist("AUTHORITY")) != 0)
+		type = PP2_TYPE_AUTHORITY;
+	else if (isteqi(input, ist("CRC32C")) != 0)
+		type = PP2_TYPE_CRC32C;
+	else if (isteqi(input, ist("NOOP")) != 0)
+		type = PP2_TYPE_NOOP;
+	else if (isteqi(input, ist("UNIQUE_ID")) != 0)
+		type = PP2_TYPE_UNIQUE_ID;
+	else if (isteqi(input, ist("SSL")) != 0)
+		type = PP2_TYPE_SSL;
+	else if (isteqi(input, ist("SSL_VERSION")) != 0)
+		type = PP2_SUBTYPE_SSL_VERSION;
+	else if (isteqi(input, ist("SSL_CN")) != 0)
+		type = PP2_SUBTYPE_SSL_CN;
+	else if (isteqi(input, ist("SSL_CIPHER")) != 0)
+		type = PP2_SUBTYPE_SSL_CIPHER;
+	else if (isteqi(input, ist("SSL_SIG_ALG")) != 0)
+		type = PP2_SUBTYPE_SSL_SIG_ALG;
+	else if (isteqi(input, ist("SSL_KEY_ALG")) != 0)
+		type = PP2_SUBTYPE_SSL_KEY_ALG;
+	else if (isteqi(input, ist("NETNS")) != 0)
+		type = PP2_TYPE_NETNS;
+	else {
+		type = strtoul(input.ptr, &endp, 0);
+		if (endp && *endp != '\0') {
+			memprintf(err, "Could not convert type '%s'", input.ptr);
+			return 0;
+		}
 	}
 
 	if (type < 0 || type > 255) {
-		memprintf(err, "Invalid TLV Type '%s'", args[0].data.str.area);
+		memprintf(err, "Invalid TLV Type '%s'", input.ptr);
 		return 0;
 	}
 

--- a/src/connection.c
+++ b/src/connection.c
@@ -15,6 +15,7 @@
 #include <import/ebmbtree.h>
 
 #include <haproxy/api.h>
+#include <haproxy/arg.h>
 #include <haproxy/cfgparse.h>
 #include <haproxy/connection.h>
 #include <haproxy/fd.h>
@@ -2198,11 +2199,77 @@ int smp_fetch_fc_rcvd_proxy(const struct arg *args, struct sample *smp, const ch
 	return 1;
 }
 
+/*
+ * This function checks the TLV type converter configuration.
+ * It expects the corresponding TLV type as a string representing the number.
+ * args[0] will be turned into the numerical value of the TLV type string.
+ */
+static int smp_check_tlv_type(struct arg *args, char **err)
+{
+	int type;
+	char *endp;
+
+	type = strtoul(args[0].data.str.area, &endp, 0);
+	if (endp && *endp != '\0') {
+		memprintf(err, "Could not convert type '%s'", args[0].data.str.area);
+		return 0;
+	}
+
+	if (type < 0 || type > 255) {
+		memprintf(err, "Invalid TLV Type '%s'", args[0].data.str.area);
+		return 0;
+	}
+
+	chunk_destroy(&args[0].data.str);
+	args[0].type = ARGT_SINT;
+	args[0].data.sint = type;
+
+	return 1;
+}
+
+/* fetch an arbitrary TLV from a PROXY protocol v2 header */
+int smp_fetch_fc_pp_tlv(const struct arg *args, struct sample *smp, const char *kw, void *private)
+{
+	int idx;
+	struct connection *conn = NULL;
+	struct conn_tlv_list *conn_tlv = NULL;
+
+	conn = objt_conn(smp->sess->origin);
+	if (!conn)
+		return 0;
+
+	if (conn->flags & CO_FL_WAIT_XPRT) {
+		smp->flags |= SMP_F_MAY_CHANGE;
+		return 0;
+	}
+
+	if (args[0].type != ARGT_SINT)
+		return 0;
+
+	idx = args[0].data.sint;
+	conn_tlv = smp->ctx.p ? smp->ctx.p : LIST_ELEM(conn->tlv_list.n, struct conn_tlv_list *, list);
+	list_for_each_entry_from(conn_tlv, &conn->tlv_list, list) {
+		if (conn_tlv->type == idx) {
+			smp->flags |= SMP_F_NOT_LAST;
+			smp->data.type = SMP_T_STR;
+			smp->data.u.str.area = conn_tlv->value;
+			smp->data.u.str.data = conn_tlv->len;
+			smp->ctx.p = conn_tlv;
+
+			return 1;
+		}
+	}
+
+	smp->flags &= ~SMP_F_NOT_LAST;
+
+	return 0;
+}
+
 /* fetch the authority TLV from a PROXY protocol header */
 int smp_fetch_fc_pp_authority(const struct arg *args, struct sample *smp, const char *kw, void *private)
 {
 	struct connection *conn = NULL;
-	struct conn_tlv_list *conn_tlv;
+	struct conn_tlv_list *conn_tlv = NULL;
 
 	conn = objt_conn(smp->sess->origin);
 	if (!conn)
@@ -2235,7 +2302,7 @@ int smp_fetch_fc_pp_authority(const struct arg *args, struct sample *smp, const 
 int smp_fetch_fc_pp_unique_id(const struct arg *args, struct sample *smp, const char *kw, void *private)
 {
 	struct connection *conn = NULL;
-	struct conn_tlv_list *conn_tlv;
+	struct conn_tlv_list *conn_tlv = NULL;
 
 	conn = objt_conn(smp->sess->origin);
 	if (!conn)
@@ -2338,6 +2405,7 @@ static struct sample_fetch_kw_list sample_fetch_keywords = {ILH, {
 	{ "fc_rcvd_proxy", smp_fetch_fc_rcvd_proxy, 0, NULL, SMP_T_BOOL, SMP_USE_L4CLI },
 	{ "fc_pp_authority", smp_fetch_fc_pp_authority, 0, NULL, SMP_T_STR, SMP_USE_L4CLI },
 	{ "fc_pp_unique_id", smp_fetch_fc_pp_unique_id, 0, NULL, SMP_T_STR, SMP_USE_L4CLI },
+	{ "fc_pp_tlv", smp_fetch_fc_pp_tlv, ARG1(1, STR), smp_check_tlv_type, SMP_T_STR, SMP_USE_L4CLI },
 	{ /* END */ },
 }};
 

--- a/src/connection.c
+++ b/src/connection.c
@@ -37,7 +37,7 @@
 DECLARE_POOL(pool_head_connection,     "connection",     sizeof(struct connection));
 DECLARE_POOL(pool_head_conn_hash_node, "conn_hash_node", sizeof(struct conn_hash_node));
 DECLARE_POOL(pool_head_sockaddr,       "sockaddr",       sizeof(struct sockaddr_storage));
-DECLARE_POOL(pool_head_authority,      "authority",      PP2_AUTHORITY_MAX);
+DECLARE_POOL(pool_head_authority,      "authority",      HA_PP2_AUTHORITY_MAX);
 
 struct idle_conns idle_conns[MAX_THREADS] = { };
 struct xprt_ops *registered_xprt[XPRT_ENTRIES] = { NULL, };
@@ -1040,7 +1040,7 @@ int conn_recv_proxy(struct connection *conn, int flag)
 				uint32_t n_crc32c;
 
 				/* Verify that this TLV is exactly 4 bytes long */
-				if (istlen(tlv) != 4)
+				if (istlen(tlv) != PP2_CRC32C_LEN)
 					goto bad_header;
 
 				n_crc32c = read_n32(istptr(tlv));
@@ -1061,12 +1061,12 @@ int conn_recv_proxy(struct connection *conn, int flag)
 			}
 #endif
 			case PP2_TYPE_AUTHORITY: {
-				if (istlen(tlv) > PP2_AUTHORITY_MAX)
+				if (istlen(tlv) > HA_PP2_AUTHORITY_MAX)
 					goto bad_header;
 				conn->proxy_authority = ist2(pool_alloc(pool_head_authority), 0);
 				if (!isttest(conn->proxy_authority))
 					goto fail;
-				if (istcpy(&conn->proxy_authority, tlv, PP2_AUTHORITY_MAX) < 0) {
+				if (istcpy(&conn->proxy_authority, tlv, HA_PP2_AUTHORITY_MAX) < 0) {
 					/* This is impossible, because we verified that the TLV value fits. */
 					my_unreachable();
 					goto fail;


### PR DESCRIPTION
This PR aims to make any TLV payload accessible via a sample fetch.

**Design**:
- _Do not break the existing API_: Keep methods for authority and unique ID, but refactor them internally with the updated, generified logic.
- _Keep existing behavior and performance_: Pools for authority and unique ID are still used. Already implemented parsing logic is still applied. All information about a TLV payload that is already should be used for validation.
- _Small memory footprint_: As there might be up to 50k connections, an array or hash map is too memory intensive. A simple list is used. It is the best choice here, as typically there are only a handful of TLVs. Additionally, memory pooling is used where possible. When TLVs become too large there is a fallback to malloc.

Note that I choose to not overwrite existing TLVs in the list. This would be relevant when there are duplicate TLVs.
This way, we return always the first found but would allow duplicate entries.
